### PR TITLE
fix(argo): Ingress template

### DIFF
--- a/charts/argo/templates/server-ingress.yaml
+++ b/charts/argo/templates/server-ingress.yaml
@@ -3,7 +3,7 @@
 {{- $serviceName := printf "%s-%s" .Release.Name .Values.server.name -}}
 {{- $servicePort := .Values.server.servicePort -}}
 {{/* Post 1.19 */}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -46,12 +46,11 @@ spec:
                 name: {{ $serviceName }}
                 port:
                   number: {{ $servicePort }}
-    {{- end -}}
+  {{- end -}}
   {{- if .Values.server.ingress.tls }}
   tls:
 {{ toYaml .Values.server.ingress.tls | indent 4 }}
   {{- end -}}
-{{- end -}}
 {{- else }}
 {{/* Pre 1.19 */}}
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
@@ -91,5 +90,9 @@ spec:
   tls:
 {{ toYaml .Values.server.ingress.tls | indent 4 }}
   {{- end -}}
+{{/* End if/else '.Capabilities.APIVersions.Has' */}}
 {{- end -}}
+{{/* End if '.Values.server.ingress.enabled' */}}
+{{- end -}}
+{{/* End if '.Values.server.enabled' */}}
 {{- end -}}


### PR DESCRIPTION
According to [Helm documentation](https://helm.sh/docs/chart_template_guide/builtin_objects/), the built-in object `Capabilities.APIVersions.Has`
should be able to check Kubernetes API Versions (as its name suggests)
and API Resources ...

As mentionned in [this issue](https://github.com/helm/helm/issues/9088):

> `helm template` somehow does not fetch "resource types" during usage of `.Capabilities.APIVersions.Has` queries.

I have tried to update the whole "stack" to the latest version:

* `helm`: 3.2.0 -> 3.11.2
* `helm-git` plugin: 0.14.2 -> 0.15.1

But ran into multiple succesive issues ...

* Needed additonnal options for `helm-git` to be able to use this git
  based helm repo
* Helm wants to use the new "gke-gcloud-auth-plugin" for diffing
* ...

Therefore, I have removed the "Resource" format in the `Capabilities.APIVersions.Has` condition to rely only on the API Versions.
I think it should be enough to be able to apply the changes now, since
this chart is alread a deprecated one...
