### PR TITLE
chore: update resources and permissions for Argo workflows v2.12.13

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: v2.11.7
+appVersion: v2.12.13
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.13.8-virtuo.3
+version: 0.13.9-virtuo.1
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/xakraz/charts-1
 deprecated: true

--- a/charts/argo/templates/server-cluster-roles.yaml
+++ b/charts/argo/templates/server-cluster-roles.yaml
@@ -30,11 +30,13 @@ rules:
   - serviceaccounts
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:
   - secrets
   verbs:
+  - create
   - get
 {{- with .Values.server.rbac.secretWhitelist }}
   resourceNames: {{- toYaml . | nindent 4 }}

--- a/charts/argo/templates/workflow-aggregate-roles.yaml
+++ b/charts/argo/templates/workflow-aggregate-roles.yaml
@@ -14,6 +14,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -40,6 +42,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows
@@ -71,6 +75,8 @@ rules:
   resources:
   - workflows
   - workflows/finalizers
+  - workfloweventbindings
+  - workfloweventbindings/finalizers
   - workflowtemplates
   - workflowtemplates/finalizers
   - cronworkflows

--- a/charts/argo/templates/workflow-controller-cluster-roles.yaml
+++ b/charts/argo/templates/workflow-controller-cluster-roles.yaml
@@ -31,6 +31,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
 - apiGroups:
   - argoproj.io
   resources:

--- a/charts/argo/values.yaml
+++ b/charts/argo/values.yaml
@@ -7,7 +7,7 @@ images:
   # Secrets with credentials to pull images from a private registry
   pullSecrets: []
   # - name: argo-pull-secret
-  tag: v2.11.7
+  tag: v2.12.13
 
 crdVersion: v1alpha1
 installCRD: true


### PR DESCRIPTION
- Update `argo` app version to `v2.12.13`
- Add `list` and `create` permissions for `secrets`
- Add `workfloweventbindings` and `workfloweventbindings/finalizers` resources to the `workflow-aggregate-roles.yaml`
- Add `get` permission for `workflow-controller-cluster-roles.yaml`
- Update `argo` image tag to `v2.12.13` in `values.yaml`
